### PR TITLE
Fix/bounding box coordinates scale

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,7 +7,8 @@ st.set_option('deprecation.showfileUploaderEncoding', False)
 st.header("Cropper Demo")
 img_file = st.sidebar.file_uploader(label='Upload a file', type=['png', 'jpg'])
 realtime_update = st.sidebar.checkbox(label="Update in Real Time", value=True)
-box_color = st.sidebar.beta_color_picker(label="Box Color", value='#0000FF')
+box_color = st.sidebar.color_picker(label="Box Color", value='#0000FF')
+
 aspect_choice = st.sidebar.radio(label="Aspect Ratio", options=["1:1", "16:9", "4:3", "2:3", "Free"])
 aspect_dict = {"1:1": (1,1),
                 "16:9": (16,9),

--- a/app.py
+++ b/app.py
@@ -10,22 +10,52 @@ realtime_update = st.sidebar.checkbox(label="Update in Real Time", value=True)
 box_color = st.sidebar.color_picker(label="Box Color", value='#0000FF')
 
 aspect_choice = st.sidebar.radio(label="Aspect Ratio", options=["1:1", "16:9", "4:3", "2:3", "Free"])
-aspect_dict = {"1:1": (1,1),
-                "16:9": (16,9),
-                "4:3": (4,3),
-                "2:3": (2,3),
-                "Free": None}
+aspect_dict = {
+    "1:1": (1, 1),
+    "16:9": (16, 9),
+    "4:3": (4, 3),
+    "2:3": (2, 3),
+    "Free": None
+}
 aspect_ratio = aspect_dict[aspect_choice]
+
+return_type_choice = st.sidebar.radio(label="Return type", options=["Cropped image", "Rect coords"])
+return_type_dict = {
+    "Cropped image": "image",
+    "Rect coords": "box"
+}
+return_type = return_type_dict[return_type_choice]
 
 if img_file:
     img = Image.open(img_file)
-    if not realtime_update:
-        st.write("Double click to save crop")
-    # Get a cropped image from the frontend
-    cropped_img = st_cropper(img, realtime_update=realtime_update, box_color=box_color,
-                                aspect_ratio=aspect_ratio)
-    
-    # Manipulate cropped image at will
-    st.write("Preview")
-    _ = cropped_img.thumbnail((150,150))
-    st.image(cropped_img)
+
+    if return_type == 'box':
+        rect = st_cropper(
+            img,
+            realtime_update=True,
+            box_color=box_color,
+            aspect_ratio=aspect_ratio,
+            return_type=return_type
+        )
+        raw_image = np.asarray(img).astype('uint8')
+        left, top, width, height = tuple(map(int, rect.values()))
+        st.write(rect)
+        masked_image = np.zeros(raw_image.shape, dtype='uint8')
+        masked_image[top:top + height, left:left + width] = raw_image[top:top + height, left:left + width]
+        st.image(Image.fromarray(masked_image), caption='masked image')
+    else:
+        if not realtime_update:
+            st.write("Double click to save crop")
+        # Get a cropped image from the frontend
+        cropped_img = st_cropper(
+            img,
+            realtime_update=realtime_update,
+            box_color=box_color,
+            aspect_ratio=aspect_ratio,
+            return_type=return_type
+        )
+
+        # Manipulate cropped image at will
+        st.write("Preview")
+        _ = cropped_img.thumbnail((150, 150))
+        st.image(cropped_img)

--- a/streamlit_cropper/__init__.py
+++ b/streamlit_cropper/__init__.py
@@ -164,7 +164,8 @@ if not _RELEASE:
     st.header("Cropper Testing")
     img_file = st.sidebar.file_uploader(label='Upload a file', type=['png', 'jpg'])
     realtime_update = st.sidebar.checkbox(label="Update in Real Time", value=True)
-    box_color = st.sidebar.beta_color_picker(label="Box Color", value='#0000FF')
+    box_color = st.sidebar.color_picker(label="Box Color", value='#0000FF')
+
     aspect_choice = st.sidebar.radio(label="Aspect Ratio", options=["1:1", "16:9", "4:3", "2:3", "Free"])
     aspect_dict = {"1:1": (1,1),
                    "16:9": (16,9),


### PR DESCRIPTION
This is a sample app to reproduce the problem reported in issues #5 and #7.

``` python
import numpy as np
import streamlit as st
from streamlit_cropper import st_cropper, _resize_img
from PIL import Image

st.set_option('deprecation.showfileUploaderEncoding', False)

# Upload an image and set some options for demo purposes
st.header("Cropper Demo")
img_file = st.sidebar.file_uploader(label='Upload a file', type=['png', 'jpg'])

if img_file:
    img = Image.open(img_file)
    rect = st_cropper(
        img,
        realtime_update=True,
        return_type='box'
    )

    resized_img = _resize_img(img)
    resized_ratio_w = img.width / resized_img.width
    resized_ratio_h = img.height / resized_img.height
    raw_image = np.asarray(img).astype('uint8')

    left, top, width, height = tuple(map(int, rect.values()))
    masked_image = np.zeros(raw_image.shape, dtype='uint8')
    masked_image[top:top + height, left:left + width] = raw_image[top:top + height, left:left + width]

    masked_image_fixed = np.zeros(raw_image.shape, dtype='uint8')
    rect['left'] = int(rect['left'] * resized_ratio_w)
    rect['width'] = int(rect['width'] * resized_ratio_w)
    rect['top'] = int(rect['top'] * resized_ratio_h)
    rect['height'] = int(rect['height'] * resized_ratio_h)
    left, top, width, height = tuple(map(int, rect.values()))
    masked_image_fixed[top:top + height, left:left + width] = raw_image[top:top + height, left:left + width]

    col1, col2 = st.columns(2)
    col1.image(Image.fromarray(masked_image), caption='wrong coords')
    col2.image(Image.fromarray(masked_image_fixed), caption='fixed coords')

```

Agreeing with the solution proposed by @ListIndexOutOfRange [here](https://github.com/turner-anderson/streamlit-cropper/issues/7#issuecomment-897504153), I implemented and tested it in this PR.

The proposed solution is to return a scaled box according to the resize ratio when `return_type='box'` is requested, to return the original coordinates of the source image.

Closes #5, closes #7